### PR TITLE
Fix failing test by increasing Jest timeout for said test

### DIFF
--- a/fiftyone.pipeline.engines.fiftyone/tests/shareUsage.test.js
+++ b/fiftyone.pipeline.engines.fiftyone/tests/shareUsage.test.js
@@ -398,7 +398,7 @@ test('share usage - send  more than once', done => {
       }, 5000);
     });
   });
-});
+}, 8000);
 
 /**
  * Check that small portion sharing is done correctly.


### PR DESCRIPTION
This PR addresses a specific failing test by increasing the Jest timeout.

The adjustment in timeout should improve the reliability of the affected test.
