### PR TITLE
Fix typo in tracker's function return type

### DIFF
--- a/fiftyone.pipeline.engines/tracker.js
+++ b/fiftyone.pipeline.engines/tracker.js
@@ -49,7 +49,7 @@ class Tracker extends DataKeyedCache {
    * If object is found in cache, the match function is called
    *
    * @param {object} result of the track function
-   * @returns {Boolen} whether a match has been made
+   * @returns {boolean} whether a match has been made
    */
   match (result) {
     return true;

--- a/fiftyone.pipeline.engines/types/tracker.d.ts
+++ b/fiftyone.pipeline.engines/types/tracker.d.ts
@@ -17,7 +17,7 @@ declare class Tracker extends DataKeyedCache {
      * If object is found in cache, the match function is called
      *
      * @param {object} result of the track function
-     * @returns {Boolen} whether a match has been made
+     * @returns {boolean} whether a match has been made
      */
     match(result: object): any;
 }


### PR DESCRIPTION
This PR fixes a typo in the return type of a parameter in the tracker module.

This is relevant to ensure accurate type checking and documentation.
