### PR TITLE
Increase timeout in one of `Share usage` tests

### DIFF
--- a/fiftyone.pipeline.engines.fiftyone/tests/shareUsage.test.js
+++ b/fiftyone.pipeline.engines.fiftyone/tests/shareUsage.test.js
@@ -395,10 +395,10 @@ test('share usage - send  more than once', done => {
         expect(received[1]).toContain('ua 2');
         expect(received[1]).not.toContain('ua 1');
         done();
-      }, 5000);
+      }, 6000);
     });
   });
-}, 8000);
+}, 15000);
 
 /**
  * Check that small portion sharing is done correctly.


### PR DESCRIPTION
Adjusted the timeout to ensure the test completes reliably under varying conditions
