### PR TITLE
Align resource key environment variable and configurator links

### DIFF
--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -5,6 +5,9 @@ param (
 )
 
 $env:RESOURCE_KEY = $TestResourceKey
+# Aligned environment variable name. This is checked first by the tests.
+# The legacy name above is retained for backwards compatibility.
+${env:51DEGREES_RESOURCE_KEY} = $TestResourceKey
 
 ./node/run-integration-tests.ps1 -RepoName $RepoName
 

--- a/fiftyone.pipeline.cloudrequestengine/readme.md
+++ b/fiftyone.pipeline.cloudrequestengine/readme.md
@@ -10,7 +10,7 @@ The 51Degrees Pipeline API is a generic web request intelligence and data proces
 
 This package uses the `engines` class created by the [`fiftyone.pipeline.engines`](/fiftyone.pipeline.engines#readme.md). It makes available:
 
-* A `Cloud Request Engine` which calls the 51Degrees cloud service to fetch properties and metadata about them based on a provided resource key. Get a resource key at https://configure.51degrees.com/
+* A `Cloud Request Engine` which calls the 51Degrees cloud service to fetch properties and metadata about them based on a provided resource key. A resource key with the free properties used by the tests can be created at https://configure.51degrees.com/Wkqxf3Bs
 * A `Cloud Engine` template which reads data from the Cloud Request Engine.
 
 It is used by the cloud versions of the following 51Degrees engines:
@@ -37,4 +37,8 @@ Then, navigate to the module directory and execute:
 ```
 npm test
 ```
+
+The integration tests read the resource key from the aligned
+`51DEGREES_RESOURCE_KEY` environment variable first, then the legacy
+`RESOURCE_KEY` variable.
 

--- a/fiftyone.pipeline.cloudrequestengine/tests/integration.test.js
+++ b/fiftyone.pipeline.cloudrequestengine/tests/integration.test.js
@@ -36,7 +36,10 @@ const pipelineBuilderPath = path.resolve(__dirname, '..', '..', 'fiftyone.pipeli
 const CloudEngine = require(cloudEnginePath);
 const PipelineBuilder = require(pipelineBuilderPath);
 
-const myResourceKey = process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
+// The aligned 51DEGREES_RESOURCE_KEY environment variable is checked
+// first, then the legacy RESOURCE_KEY variable.
+const myResourceKey = process.env['51DEGREES_RESOURCE_KEY'] ||
+  process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 
 /**
  * Verify that cloud engine returns isMobile property in response.
@@ -47,9 +50,10 @@ const myResourceKey = process.env.RESOURCE_KEY || '!!YOUR_RESOURCE_KEY!!';
 test('valid response', done => {
   if (myResourceKey === '!!YOUR_RESOURCE_KEY!!') {
     fail('You need to create a resource key at ' +
-        'https://configure.51degrees.com and paste it into the ' +
-        'code, replacing !!YOUR_RESOURCE_KEY!!. Please make sure ' +
-        'to include IsMobile property.');
+        'https://configure.51degrees.com/Wkqxf3Bs and supply it in ' +
+        'the 51DEGREES_RESOURCE_KEY environment variable, or paste ' +
+        'it into the code replacing !!YOUR_RESOURCE_KEY!!. Please ' +
+        'make sure to include the IsMobile property.');
   }
   const cloud = new CloudRequestEngine({
     resourceKey: myResourceKey,
@@ -80,9 +84,10 @@ test('valid response', done => {
 test('post with sequence evidence', done => {
   if (myResourceKey === '!!YOUR_RESOURCE_KEY!!') {
     fail('You need to create a resource key at ' +
-        'https://configure.51degrees.com and paste it into the ' +
-        'code, replacing !!YOUR_RESOURCE_KEY!!. Please make sure ' +
-        'to include IsMobile property.');
+        'https://configure.51degrees.com/Wkqxf3Bs and supply it in ' +
+        'the 51DEGREES_RESOURCE_KEY environment variable, or paste ' +
+        'it into the code replacing !!YOUR_RESOURCE_KEY!!. Please ' +
+        'make sure to include the IsMobile property.');
   }
 
   const cloud = new CloudRequestEngine({ resourceKey: myResourceKey });


### PR DESCRIPTION
## Summary

This change aligns the cloud integration tests with the convention shared across 51Degrees repositories.

- The integration tests read the resource key from the `51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable.
- The test failure messages and the package readme reference the shared configurator link https://configure.51degrees.com/Wkqxf3Bs, which selects the free tier properties used by the tests, including IsMobile.
- The CI script also sets the aligned name, with the legacy assignment retained.

## Notes

- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned name starts with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set it with the env command.
