### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,9 +4,9 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
 * `NPM_AUTH_TOKEN` - [NPM token](https://docs.npmjs.com/creating-and-viewing-access-tokens)  for publishing packages
     * Example: `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`

--- a/fiftyone.pipeline.cloudrequestengine/readme.md
+++ b/fiftyone.pipeline.cloudrequestengine/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **51Degrees Pipeline Cloud Request Engine**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.cloudrequestengine-readme.md&utm_term=top "Data rewards the curious") **51Degrees Pipeline Cloud Request Engine**
 
-[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.cloudrequestengine-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 
@@ -10,7 +10,7 @@ The 51Degrees Pipeline API is a generic web request intelligence and data proces
 
 This package uses the `engines` class created by the [`fiftyone.pipeline.engines`](/fiftyone.pipeline.engines#readme.md). It makes available:
 
-* A `Cloud Request Engine` which calls the 51Degrees cloud service to fetch properties and metadata about them based on a provided resource key. Get a resource key at https://configure.51degrees.com/
+* A `Cloud Request Engine` which calls the 51Degrees cloud service to fetch properties and metadata about them based on a provided resource key. Get a resource key at https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.cloudrequestengine-readme.md&utm_term=this-package-fiftyone-pipeline-cloudrequestengine
 * A `Cloud Engine` template which reads data from the Cloud Request Engine.
 
 It is used by the cloud versions of the following 51Degrees engines:

--- a/fiftyone.pipeline.core/javascriptbuilder.js
+++ b/fiftyone.pipeline.core/javascriptbuilder.js
@@ -81,7 +81,7 @@ class JavaScriptBuilderElement extends FlowElement {
    * @param {boolean} options.enableCookies Whether the client JavaScript
    * stored results of client side processing in cookies. This can also
    * be set per request, using the "query.fod-js-enable-cookies" evidence key.
-   * For more details on personal data policy, see http://51degrees.com/terms/client-services-privacy-policy/
+   * For more details on personal data policy, see https://51degrees.com/terms/client-services-privacy-policy/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.core-javascriptbuilder.js&utm_term=constructor
    * @param {boolean} options.minify Whether to minify the JavaScript
    */
   constructor ({

--- a/fiftyone.pipeline.core/readme.md
+++ b/fiftyone.pipeline.core/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **51Degrees Pipeline Core**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.core-readme.md&utm_term=top "Data rewards the curious") **51Degrees Pipeline Core**
 
-[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.core-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 The 51Degrees Pipeline API is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines) 

--- a/fiftyone.pipeline.engines.fiftyone/readme.md
+++ b/fiftyone.pipeline.engines.fiftyone/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **51Degrees Pipeline Engines Fiftyone**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.engines.fiftyone-readme.md&utm_term=top "Data rewards the curious") **51Degrees Pipeline Engines Fiftyone**
 
-[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.engines.fiftyone-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 

--- a/fiftyone.pipeline.engines/errorMessages.js
+++ b/fiftyone.pipeline.engines/errorMessages.js
@@ -24,12 +24,12 @@ module.exports = {
   cloudNoPropertiesAccess: ' This is because your resource key does not ' +
     'include access to any properties under "%s". For more details, see our ' +
     'resource key explainer: ' +
-    'https://51degrees.com/documentation/_info__resource_keys.html',
+    'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.engines-errormessages.js&utm_term=cloudnopropertiesaccess',
   cloudNoPropertyAccess: ' This is because your resource key does not ' +
     'include access to this property. Properties that are included for this ' +
     'key under "%s" are %s. For more details on resource keys, see our ' +
     'explainer: ' +
-    'https://51degrees.com/documentation/_info__resource_keys.html',
+    'https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.engines-errormessages.js&utm_term=cloudnopropertyaccess',
   cloudReasonUnknown: ' The reason for this is unknown as the supplied ' +
     'resource key does appear to allow access to this property.',
   propertyExcluded: 'Property "%s" is not present in the results. This ' +

--- a/fiftyone.pipeline.engines/readme.md
+++ b/fiftyone.pipeline.engines/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **51Degrees Pipeline Engines**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.engines-readme.md&utm_term=top "Data rewards the curious") **51Degrees Pipeline Engines**
 
-[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=fiftyone.pipeline.engines-readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=node-open-source "Data rewards the curious") **Node Pipeline**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=readme.md&utm_term=top "Data rewards the curious") **Node Pipeline**
 
-[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=node-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-node/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=readme.md&utm_term=top "developer documentation")
 
 ## Introduction
 This repository contains the components of the Node.JS implementation of the 51Degrees Pipeline API.
@@ -10,7 +10,7 @@ add a range of 51Degrees and/or custom plug ins (Engines)
 
 ## Dependencies
 
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=readme.md&utm_term=dependencies) page shows 
 the Node versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -42,7 +42,7 @@ npm install <path to module>
 ## Examples
 
 There are several examples available that demonstrate how to make use of the Pipeline API in isolation. These are described in the table below.
-If you want examples that demonstrate how to use 51Degrees products such as device detection, then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-node) and on our [website](https://51degrees.com/documentation/_examples__device_detection__index.html).
+If you want examples that demonstrate how to use 51Degrees products such as device detection, then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-node) and on our [website](https://51degrees.com/documentation/_examples__device_detection__index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-node&utm_content=readme.md&utm_term=examples).
 
 #### Core
 


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

18 links across 9 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).